### PR TITLE
Improve OCSP Responder

### DIFF
--- a/ocsp/config.go
+++ b/ocsp/config.go
@@ -32,7 +32,14 @@ type Config struct {
 	// Responder is the URL of the OCSP responder.
 	// It specifies the endpoint where the OCSP requests will be sent to check the Revocation status of client certificates.
 	// The Responder field must be set to a valid URL string.
+	//
+	// Deprecated: Use ResponderFunc Instead.
 	Responder string
+
+	// ResponderFunc is a function that takes a client certificate and returns the OCSP responder URL.
+	// It allows dynamic selection of the OCSP responder based on the client certificate.
+	// The ResponderFunc field must be set to a valid function.
+	ResponderFunc func(*x509.Certificate) string
 
 	// ResponseHandler is a function that handles the response when an error occurs.
 	// If not provided, a default JSON response handler will be used.

--- a/ocsp/docs.go
+++ b/ocsp/docs.go
@@ -10,6 +10,7 @@
 // # Usage
 //
 //	import (
+//		"crypto/x509"
 //		"github.com/gofiber/fiber/v2"
 //		"github.com/H0llyW00dzZ/ocsp-fiber/ocsp"
 //	)
@@ -18,8 +19,17 @@
 //		app := fiber.New()
 //
 //		ocspMiddleware := ocsp.New(ocsp.Config{
-//			Issuer:    issuerCert,
-//			Responder: "http://ocsp.example.com",
+//			Issuer: issuerCert,
+//			ResponderFunc: func(cert *x509.Certificate) string {
+//				// Determine the OCSP responder URL based on the client certificate
+//				if cert.Issuer.CommonName == "Example CA" {
+//					return "http://example.com/ocsp"
+//				} else if cert.Issuer.CommonName == "Another CA" {
+//					return "http://another-ca.com/ocsp"
+//				}
+//				// Default responder URL
+//				return "http://default-responder.com/ocsp"
+//			},
 //		})
 //
 //		app.Use(ocspMiddleware)

--- a/ocsp/new.go
+++ b/ocsp/new.go
@@ -40,8 +40,11 @@ func New(config Config) fiber.Handler {
 		// Create an io.Reader from the OCSP request byte slice.
 		ocspReqReader := bytes.NewReader(ocspReq)
 
+		// Get the OCSP responder URL based on the client certificate.
+		responderURL := config.ResponderFunc(clientCert)
+
 		// Send the OCSP request to the responder.
-		resp, err := http.Post(config.Responder, MIMEApplicationOCSPRequest, ocspReqReader)
+		resp, err := http.Post(responderURL, MIMEApplicationOCSPRequest, ocspReqReader)
 		if err != nil {
 			return config.ResponseHandler(c, fiber.StatusInternalServerError, fmt.Sprintf("failed to send OCSP request: %v", err))
 		}

--- a/ocsp/ocsp_test.go
+++ b/ocsp/ocsp_test.go
@@ -86,8 +86,10 @@ func TestOCSPMiddleware_ErrorCases(t *testing.T) {
 
 	// Create the OCSP middleware with the configuration.
 	ocspMiddleware := ocsp.New(ocsp.Config{
-		Issuer:    issuerCert,
-		Responder: responder.URL,
+		Issuer: issuerCert,
+		ResponderFunc: func(cert *x509.Certificate) string {
+			return responder.URL
+		},
 	})
 
 	// Create a new Fiber app
@@ -169,7 +171,6 @@ func TestOCSPMiddleware_ErrorCases(t *testing.T) {
 
 	// Make requests to the server using each client
 	for _, client := range clients {
-
 		req, err := http.NewRequest("GET", "https://localhost:443/test", nil)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
- [+] feat(ocsp): add ResponderFunc field to Config for dynamic OCSP responder selection
- [+] refactor(ocsp): deprecate Responder field in favor of ResponderFunc
- [+] docs(ocsp): update usage documentation to demonstrate ResponderFunc usage
- [+] refactor(ocsp): use ResponderFunc to determine OCSP responder URL in middleware
- [+] test(ocsp): update TestOCSPMiddleware_ErrorCases to use ResponderFunc